### PR TITLE
Use whatever java version is available

### DIFF
--- a/java-class-quick-look/GeneratePreviewForURL.m
+++ b/java-class-quick-look/GeneratePreviewForURL.m
@@ -28,7 +28,7 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
 		NSFileHandle *file = pipe.fileHandleForReading;
 		
 		NSTask *task = [[NSTask alloc] init];
-		task.launchPath = @"/Library/Java/JavaVirtualMachines/jdk1.8.0_05.jdk/Contents/Home/bin/javap";
+		task.launchPath = @"/usr/bin/javap";
 		task.arguments = @[@"-c", fileName];
 		task.standardOutput = pipe;
 		

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ This is a Quick Look plugin that lets you preview Java `.class` files as bytecod
 
 ## Requirements
 * macOS
-* Java 8 installed (project expects `/Library/Java/JavaVirtualMachines/jdk1.8.0_05.jdk` as install location)
+* Java installed
 
 ## Install
 Compile the target and copy the binary to either `/Library/QuickLook` or `~/Library/QuickLook`.


### PR DESCRIPTION
call `/usr/bin/javap` instead of whole path